### PR TITLE
SLING-11794 - Adding a new method to get the properties as an adapted type

### DIFF
--- a/src/main/java/org/apache/sling/resource/collection/ResourceCollection.java
+++ b/src/main/java/org/apache/sling/resource/collection/ResourceCollection.java
@@ -20,11 +20,11 @@ package org.apache.sling.resource.collection;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -68,10 +68,9 @@ public interface ResourceCollection {
     /**
      * Returns additional properties for a particular resource in Collection entry.
      *
-     * @return properties of the Collection entry as the specified type, returns empty if no entry found or 
-     *  the entry cannot be adapted to the type
+     * @return properties of the Collection entry as a ValueMap which will not be null
      */
-    <T> Optional<T> getPropertiesAs(Resource resource, Class<T> type);
+    ValueMap getValueMap(Resource resource);
 
     /**
      * Returns additional properties for a particular resource in Collection entry.

--- a/src/main/java/org/apache/sling/resource/collection/ResourceCollection.java
+++ b/src/main/java/org/apache/sling/resource/collection/ResourceCollection.java
@@ -20,6 +20,7 @@ package org.apache.sling.resource.collection;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
@@ -67,7 +68,16 @@ public interface ResourceCollection {
     /**
      * Returns additional properties for a particular resource in Collection entry.
      *
-     * @return properties of the Collection entry as <code>ModifiableValueMap</code>, returns null if entry found.
+     * @return properties of the Collection entry as the specified type, returns empty if no entry found or 
+     *  the entry cannot be adapted to the type
+     */
+    <T> Optional<T> getPropertiesAs(Resource resource, Class<T> type);
+
+    /**
+     * Returns additional properties for a particular resource in Collection entry.
+     *
+     * @return properties of the Collection entry as <code>ModifiableValueMap</code>, returns null if no entry found
+     *  or the entry cannot be adapted to a ModifiableValueMap
      */
     ModifiableValueMap getProperties(Resource resource);
 

--- a/src/main/java/org/apache/sling/resource/collection/impl/ResourceCollectionImpl.java
+++ b/src/main/java/org/apache/sling/resource/collection/impl/ResourceCollectionImpl.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sling.api.SlingConstants;
@@ -293,19 +294,24 @@ public class ResourceCollectionImpl implements
 		vm.put(ResourceCollectionConstants.REFERENCES_PROP, order);
 	}
 
-	@Override
-    public ModifiableValueMap getProperties(Resource resource) {
-		Iterator<Resource> entries = membersResource.listChildren();
+    @Override
+    public <T> Optional<T> getPropertiesAs(Resource resource, Class<T> type) {
+        Iterator<Resource> entries = membersResource.listChildren();
         while (entries.hasNext()) {
-        	Resource entry = entries.next();
-        	String path = ResourceUtil.getValueMap(entry).get(
-        			ResourceCollectionConstants.REF_PROPERTY, "");
+            Resource entry = entries.next();
+            String path = ResourceUtil.getValueMap(entry).get(
+                    ResourceCollectionConstants.REF_PROPERTY, "");
 
             if (resource.getPath().equals(path)) {
-            	return entry.adaptTo(ModifiableValueMap.class);
+                return Optional.ofNullable(entry.adaptTo(type));
             }
         }
 
-        return null;
-	}
+        return Optional.empty();
+    }
+
+    @Override
+    public ModifiableValueMap getProperties(Resource resource) {
+        return getPropertiesAs(resource, ModifiableValueMap.class).orElse(null);
+    }
 }

--- a/src/main/java/org/apache/sling/resource/collection/impl/ResourceCollectionImpl.java
+++ b/src/main/java/org/apache/sling/resource/collection/impl/ResourceCollectionImpl.java
@@ -35,7 +35,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
-
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.resource.collection.ResourceCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -294,8 +294,7 @@ public class ResourceCollectionImpl implements
 		vm.put(ResourceCollectionConstants.REFERENCES_PROP, order);
 	}
 
-    @Override
-    public <T> Optional<T> getPropertiesAs(Resource resource, Class<T> type) {
+    private <T> Optional<T> getPropertiesAs(Resource resource, Class<T> type) {
         Iterator<Resource> entries = membersResource.listChildren();
         while (entries.hasNext()) {
             Resource entry = entries.next();
@@ -313,5 +312,10 @@ public class ResourceCollectionImpl implements
     @Override
     public ModifiableValueMap getProperties(Resource resource) {
         return getPropertiesAs(resource, ModifiableValueMap.class).orElse(null);
+    }
+
+    @Override
+    public ValueMap getValueMap(Resource resource) {
+        return getPropertiesAs(resource, ValueMap.class).orElse(new ValueMapDecorator(new HashMap<>()));
     }
 }

--- a/src/main/java/org/apache/sling/resource/collection/package-info.java
+++ b/src/main/java/org/apache/sling/resource/collection/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("1.0.2")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.apache.sling.resource.collection;
 
 

--- a/src/test/java/org/apache/sling/resource/collection/impl/ResourceCollectionImplTest.java
+++ b/src/test/java/org/apache/sling/resource/collection/impl/ResourceCollectionImplTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.resource.PersistenceException;
@@ -224,7 +223,7 @@ public class ResourceCollectionImplTest {
 	}
 
     @Test
-    public void testCollectionPropertiesAs() throws PersistenceException {
+    public void testGetValueMap() throws PersistenceException {
         final Map<String, Object> props = new HashMap<String, Object>();
         props.put("creator", "slingdev");
 
@@ -239,37 +238,14 @@ public class ResourceCollectionImplTest {
 
         Assert.assertEquals(true, collection.contains(resource));
 
-        Optional<ValueMap> vm = collection.getPropertiesAs(resource, ValueMap.class);
+        ValueMap vm = collection.getValueMap(resource);
 
         Assert.assertNotNull(vm);
-        Assert.assertTrue(vm.isPresent());
-        Assert.assertEquals("slingdev", vm.get().get("creator", ""));
+        Assert.assertEquals("slingdev", vm.get("creator", ""));
     }
 
     @Test
-    public void testCollectionPropertiesAs__emptyOnInvalidAdaptTo() throws PersistenceException {
-        final Map<String, Object> props = new HashMap<String, Object>();
-        props.put("creator", "slingdev");
-
-        final ResourceCollection collection = rcm.createCollection(resResolver.getResource("/"), "collection3");
-
-        final Resource resource = resResolver.create(resResolver.getResource("/"), "res1",
-                Collections.singletonMap(PROPERTY_RESOURCE_TYPE, (Object) "type"));
-        collection.add(resource, props);
-
-        final Resource collectionRes = resResolver.getResource("/collection3");
-        Assert.assertNotNull(collectionRes);
-
-        Assert.assertEquals(true, collection.contains(resource));
-
-        Optional<IllegalArgumentException> vm = collection.getPropertiesAs(resource, IllegalArgumentException.class);
-
-        Assert.assertNotNull(vm);
-        Assert.assertFalse(vm.isPresent());
-    }
-
-    @Test
-    public void testCollectionPropertiesAs__emptyOnInvalidResource() throws PersistenceException {
+    public void testGetValueMap__emptyOnInvalidResource() throws PersistenceException {
 
         final ResourceCollection collection = rcm.createCollection(resResolver.getResource("/"), "collection3");
 
@@ -281,10 +257,9 @@ public class ResourceCollectionImplTest {
 
         Assert.assertEquals(false, collection.contains(resource));
 
-        Optional<ValueMap> vm = collection.getPropertiesAs(resource, ValueMap.class);
+        ValueMap vm = collection.getValueMap(resource);
 
         Assert.assertNotNull(vm);
-        Assert.assertFalse(vm.isPresent());
     }
 
 }


### PR DESCRIPTION
Changes:

 - Adds a new method to get the properties of an entry in the resource collection as a specified type
 
 
See: https://issues.apache.org/jira/browse/SLING-11794